### PR TITLE
Error thrown during fresh install on Magento 2.3.5-p1:

### DIFF
--- a/Helper/Configuration.php
+++ b/Helper/Configuration.php
@@ -32,8 +32,10 @@ class Configuration
     protected function getConfig()
     {
         if ($this->config === null) {
+        	$options = $this->scopeConfig->getValue(self::XML_PATH_CACHE_CLEANUP_DEBUGGER_CONFIGURATION);
+        	$options = is_array($options)?$options:[];
             $this->config = new \Magento\Framework\DataObject(
-                $this->scopeConfig->getValue(self::XML_PATH_CACHE_CLEANUP_DEBUGGER_CONFIGURATION)
+                $options
             );
         }
 


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\Framework\DataObject::__construct() must be of the type array, null given, called in vendor/creativestyle/magesuite-cache/Helper/Configuration.php on line 36 and defined in vendor/magento/framework/DataObject.php:39

Queried config options are empty at this stage, added value initialization for correct instantiation of DataObject.